### PR TITLE
fix: set lowcase_key and next fields on adding new http header

### DIFF
--- a/nginx_module/src/http_request.rs
+++ b/nginx_module/src/http_request.rs
@@ -572,6 +572,8 @@ impl<'a> HeaderList<'a> {
         h.hash = 1;
         h.key = name.inner();
         h.value = value.inner();
+        h.lowcase_key = name.inner().data;
+        h.next = std::ptr::null_mut();
         Ok(())   
     }
 


### PR DESCRIPTION
fix for https://jira.gcore.lu/browse/CDP-1482