### PR TITLE
EPX-6: event_expire_timers SEGV

### DIFF
--- a/nginx_module/src/unix_socket.rs
+++ b/nginx_module/src/unix_socket.rs
@@ -273,7 +273,7 @@ impl Drop for State {
                 }
             },
             Self::Disconnected { event, .. } => unsafe {
-                if event.active() != 0 {
+                if event.timer_set() != 0 {
                     ngx_event_del_timer(event.as_mut());
                 }
             },


### PR DESCRIPTION
The core dump is always preceded by an error:
on_reconnect_timeout: state borrow: RefCell already borrowed

ev->active is not the thing to check before ngx_event_add_timer or ngx_event_del_timer