### PR TITLE
ICM-48411: set new ngx_peer_connection hint/sid fields for nginx 1.30

### DIFF
--- a/nginx_module/src/unix_socket.rs
+++ b/nginx_module/src/unix_socket.rs
@@ -237,6 +237,8 @@ impl State {
             type_: 0,
             rcvbuf: 0,
             log,
+            hint: std::ptr::null_mut(),
+            sid: std::ptr::null_mut(),
             _bitfield_align_1: Default::default(),
             _bitfield_1: Default::default(),
             __bindgen_padding_0: Default::default(),


### PR DESCRIPTION
## Summary

- Updates \`ngx_peer_connection_t\` field access to match the new \`hint\` and \`sid\` fields introduced in nginx 1.30.2, replacing the fields that were reorganized upstream.

## Related PRs

- ngx_http_fastedge: G-Core/ngx_http_fastedge#75

## Test plan

- [ ] Build nginx-gcdn against nginx 1.30.2 with this change
- [ ] Verify fastedge module compiles without errors